### PR TITLE
make add new task screen complete

### DIFF
--- a/lib/app/todo_app.dart
+++ b/lib/app/todo_app.dart
@@ -1,16 +1,18 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:todo_app/config/config.dart';
-import 'package:todo_app/screens/screens.dart';
+import 'package:todo_app/config/routes/routes.dart';
 
-class TodoApp extends StatelessWidget {
+class TodoApp extends ConsumerWidget {
   const TodoApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
+  Widget build(BuildContext context,WidgetRef ref) {
+    final routeConfig = ref.watch(routesProvider);
+    return MaterialApp.router(
       debugShowCheckedModeBanner: false,
-      theme: AppTheme.light,
-      home: HomeScreen(),
+      theme:AppTheme.light,
+      routerConfig: routeConfig,
     );
   }
 }

--- a/lib/config/routes/app_route.dart
+++ b/lib/config/routes/app_route.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:todo_app/config/routes/routes.dart';
+import 'package:todo_app/screens/screens.dart';
+
+final navigationKey = GlobalKey<NavigatorState>();
+
+final appRoutes = [
+  GoRoute(
+    path: RouteLocation.home,
+    parentNavigatorKey: navigationKey,
+    builder: HomeScreen.builder,
+  ),
+  GoRoute(
+    path: RouteLocation.createTask,
+    parentNavigatorKey: navigationKey,
+    builder: CreateTaskScreen.builder,
+    )
+ 
+];

--- a/lib/config/routes/route_location.dart
+++ b/lib/config/routes/route_location.dart
@@ -1,0 +1,10 @@
+
+import 'package:flutter/material.dart';
+
+@immutable
+class RouteLocation {
+  const RouteLocation._();
+
+  static String get home => '/home';
+  static String get createTask => '/createTask';
+}

--- a/lib/config/routes/routes.dart
+++ b/lib/config/routes/routes.dart
@@ -1,0 +1,3 @@
+export 'app_route.dart';
+export 'route_location.dart';
+export 'routes_provider.dart';

--- a/lib/config/routes/routes_provider.dart
+++ b/lib/config/routes/routes_provider.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:todo_app/config/routes/routes.dart';
+
+final routesProvider = Provider<GoRouter>(
+  (ref) {
+    return GoRouter(
+      initialLocation: RouteLocation.home,
+      navigatorKey: navigationKey,
+      routes: appRoutes,
+    );
+  },
+);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:todo_app/app/todo_app.dart';
 void main(){
-  runApp(const TodoApp());
+  runApp(const ProviderScope(
+    child:TodoApp()
+  ));
 }
 

--- a/lib/providers/categories_provider.dart
+++ b/lib/providers/categories_provider.dart
@@ -1,0 +1,6 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:todo_app/utils/utils.dart';
+
+final categoryProvider = StateProvider.autoDispose<TasksCategories>((ref) {
+  return TasksCategories.others;
+});

--- a/lib/providers/date_provider.dart
+++ b/lib/providers/date_provider.dart
@@ -1,0 +1,5 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final dateProvider = StateProvider<DateTime>((ref) {
+  return DateTime.now();
+});

--- a/lib/providers/providers.dart
+++ b/lib/providers/providers.dart
@@ -1,0 +1,3 @@
+export 'date_provider.dart';
+export 'time_provider.dart';
+export 'categories_provider.dart';

--- a/lib/providers/time_provider.dart
+++ b/lib/providers/time_provider.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final timeProvider = StateProvider.autoDispose<TimeOfDay>((ref) {
+  return TimeOfDay.now();
+});

--- a/lib/screens/create_task_screen.dart
+++ b/lib/screens/create_task_screen.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
+import 'package:go_router/go_router.dart';
+import 'package:todo_app/widgets/widgets.dart';
+
+class CreateTaskScreen extends StatelessWidget {
+  static CreateTaskScreen builder(BuildContext context, GoRouterState state) =>
+      const CreateTaskScreen();
+  const CreateTaskScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const DisplayWhiteText(text: "Add New Task"),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          padding: const EdgeInsets.all(20.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const CommonTextField(hintText: 'Title Text', title: 'Title Text'),
+              const Gap(30),
+              const CategoriesSelection(),
+              const Gap(30),
+              const SelectDateTime(),
+              const Gap(30),
+              const Gap(16),
+              const CommonTextField(
+                hintText: 'Task Note',
+                title: 'Note',
+                maxLines: 5,
+              ),
+              const Gap(60),
+              ElevatedButton(
+                  onPressed: () {}, child: const DisplayWhiteText(text: 'Save'))
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
+import 'package:go_router/go_router.dart';
+import 'package:todo_app/config/routes/route_location.dart';
 import 'package:todo_app/data/data.dart';
 import 'package:todo_app/utils/utils.dart';
 import 'package:todo_app/widgets/widgets.dart';
 
 class HomeScreen extends StatelessWidget {
+  static HomeScreen builder(BuildContext context,GoRouterState state) => const HomeScreen();
   const HomeScreen({super.key});
 
   @override
@@ -96,7 +99,7 @@ class HomeScreen extends StatelessWidget {
                       ),
                     const Gap(20),
                     ElevatedButton(
-                        onPressed: () {},
+                        onPressed: () => context.push(RouteLocation.createTask),
                         child: const Padding(
                           padding: EdgeInsets.all(8.0),
                           child: DisplayWhiteText(text: 'Add New Task'),

--- a/lib/screens/screens.dart
+++ b/lib/screens/screens.dart
@@ -1,1 +1,2 @@
 export 'home_screen.dart';
+export 'create_task_screen.dart';

--- a/lib/utils/helpers.dart
+++ b/lib/utils/helpers.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:intl/intl.dart';
+import 'package:todo_app/data/models/models.dart';
+import 'package:todo_app/providers/providers.dart';
+
+@immutable
+class Helpers {
+  const Helpers._();
+  static String timeToString(TimeOfDay time) {
+    try {
+      final DateTime now = DateTime.now();
+      final date = DateTime(
+        now.year,
+        now.month,
+        now.day,
+        time.hour,
+        time.minute,
+      );
+      final formatType = DateFormat.jm();
+      return formatType.format(date);
+    } catch (e) {
+      return '12:00';
+    }
+  }
+
+  static void selectDate(BuildContext context, WidgetRef ref) async {
+    final initialDate = ref.read(dateProvider);
+    DateTime? pickedDate = await showDatePicker(
+      context: context,
+      initialDate: initialDate,
+      firstDate: DateTime(2023),
+      lastDate: DateTime(2060),
+    );
+
+    if (pickedDate != null) {
+      ref.read(dateProvider.notifier).state = pickedDate;
+    }
+  }
+
+  static bool isTaskFromSelectedDate(Task task, DateTime selectedDate) {
+    final DateTime taskDate = _stringToDateTime(task.date);
+    if (taskDate.month == selectedDate.month &&
+        taskDate.year == selectedDate.year &&
+        taskDate.day == selectedDate.day) {
+      return true;
+    }
+    return false;
+  }
+
+  static DateTime _stringToDateTime(String dateString) {
+    try {
+      DateFormat format = DateFormat.yMMMd();
+      return format.parse(dateString);
+    } catch (e) {
+      return DateTime.now();
+    }
+  }
+
+  static String dateFormatter(DateTime date) {
+    try {
+      return DateFormat.yMMMd().format(date);
+    } catch (e) {
+      return DateFormat.yMMMd().format(
+        DateTime.now(),
+      );
+    }
+  }
+}

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,2 +1,3 @@
 export 'extensions.dart';
 export 'tasks_categories.dart';
+export 'helpers.dart';

--- a/lib/widgets/common_textfield.dart
+++ b/lib/widgets/common_textfield.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
+import 'package:todo_app/utils/utils.dart';
+
+class CommonTextField extends StatelessWidget {
+  const CommonTextField({
+    super.key,
+    this.controller,
+    required this.hintText,
+    required this.title,
+    this.maxLines,
+    this.suffixIcon,
+    this.readOnly = false,
+  });
+  final TextEditingController? controller;
+  final String hintText;
+  final String title;
+  final int? maxLines;
+  final Widget? suffixIcon;
+  final bool readOnly;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          title,
+          style: context.textTheme.titleLarge,
+        ),
+        const Gap(10),
+        TextField(
+          readOnly: readOnly,
+          onTapOutside: (event) {
+            FocusManager.instance.primaryFocus?.unfocus();
+          },
+          autocorrect: false,
+          controller: controller,
+          decoration: InputDecoration(
+            hintText: hintText,
+            suffixIcon: suffixIcon,
+          ),
+          maxLines: maxLines,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/display_list_task.dart
+++ b/lib/widgets/display_list_task.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:todo_app/data/data.dart';
 import 'package:todo_app/utils/utils.dart';
+import 'package:todo_app/widgets/task_details.dart';
 import 'package:todo_app/widgets/widgets.dart';
 
 class DisplayListTask extends StatelessWidget {

--- a/lib/widgets/select_categories.dart
+++ b/lib/widgets/select_categories.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
+import 'package:todo_app/providers/providers.dart';
+import 'package:todo_app/utils/utils.dart';
+import 'package:todo_app/widgets/widgets.dart';
+
+class CategoriesSelection extends ConsumerWidget {
+  const CategoriesSelection({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedCategory = ref.watch(categoryProvider);
+    final List<TasksCategories> categories = TasksCategories.values.toList();
+
+    return SizedBox(
+      height: 60,
+      child: Row(
+        children: [
+          Text(
+            'Category',
+            style: context.textTheme.titleLarge,
+          ),
+          const Gap(10),
+          Expanded(
+            child: ListView.separated(
+              itemCount: categories.length,
+              shrinkWrap: true,
+              scrollDirection: Axis.horizontal,
+              physics: const AlwaysScrollableScrollPhysics(),
+              itemBuilder: (ctx, index) {
+                final category = categories[index];
+
+                return InkWell(
+                  onTap: () {
+                    ref.read(categoryProvider.notifier).state = category;
+                  },
+                  borderRadius: BorderRadius.circular(30),
+                  child: CircleContainer(
+                    color: category.color.withOpacity(0.3),
+                    borderColor: category.color,
+                    child: Icon(
+                      category.icon,
+                      color: selectedCategory == category
+                          ? context.colorScheme.primary
+                          : category.color.withOpacity(0.5),
+                    ),
+                  ),
+                );
+              },
+              separatorBuilder: (context, index) => const Gap(8),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/select_date_time.dart
+++ b/lib/widgets/select_date_time.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:gap/gap.dart';
+import 'package:todo_app/providers/providers.dart';
+import 'package:todo_app/utils/utils.dart';
+import 'package:todo_app/widgets/widgets.dart';
+
+class SelectDateTime extends ConsumerWidget {
+  const SelectDateTime({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final time = ref.watch(timeProvider);
+    final date = ref.watch(dateProvider);
+
+    return Row(
+      children: [
+        Expanded(
+          child: CommonTextField(
+            title: 'Date',
+            hintText: Helpers.dateFormatter(date),
+            readOnly: true,
+            suffixIcon: IconButton(
+              onPressed: () => Helpers.selectDate(context, ref),
+              icon: const FaIcon(FontAwesomeIcons.calendar),
+            ),
+          ),
+        ),
+        const Gap(10),
+        Expanded(
+          child: CommonTextField(
+            title: 'Time',
+            hintText: Helpers.timeToString(time),
+            readOnly: true,
+            suffixIcon: IconButton(
+              onPressed: () => _selectTime(context, ref),
+              icon: const FaIcon(FontAwesomeIcons.clock),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _selectTime(BuildContext context, WidgetRef ref) async {
+    TimeOfDay? pickedTime = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.now(),
+    );
+    if (pickedTime != null) {
+      ref.read(timeProvider.notifier).state = pickedTime;
+    }
+  }
+}

--- a/lib/widgets/task_details.dart
+++ b/lib/widgets/task_details.dart
@@ -72,7 +72,7 @@ class TaskDetails extends StatelessWidget {
             ),
           ),
       ],
-      ),
+      ),  
     );
   }
 }

--- a/lib/widgets/task_tile.dart
+++ b/lib/widgets/task_tile.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 import 'package:todo_app/data/data.dart';
 import 'package:todo_app/utils/extensions.dart';
-import 'package:todo_app/widgets/widgets.dart';
+import 'package:todo_app/widgets/circle_container.dart';
 
 class TaskTile extends StatelessWidget {
   const TaskTile({super.key, required this.task, this.onCompleted});

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -4,3 +4,6 @@ export 'display_list_task.dart';
 export 'task_tile.dart';
 export 'task_details.dart';
 export 'circle_container.dart';
+export 'common_textfield.dart';
+export 'select_date_time.dart';
+export 'select_categories.dart';


### PR DESCRIPTION
The `CreateTaskScreen` is a user-friendly interface in the Flutter app where users can add a new task by entering a title, selecting a category, setting a date and time, and writing task details. The screen provides a streamlined layout for easy task creation and includes a save option to store the task.

- **Task Creation**: Allows users to add a new task with a title, category, date, and time.
- **Category Selection**: Includes an intuitive category selector to organize tasks efficiently.
- **Date & Time Picker**: Enables users to set a specific date and time for task scheduling.
- **Task Details Input**: Provides a dedicated field for adding detailed notes about the task.
- **Save Functionality**: Offers a simple button to save the task once all details are entered.